### PR TITLE
fix executeContract + bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "yarn": "1.9.4"
   },
   "dependencies": {
-    "@zen/zenjs": "0.0.22",
+    "@zen/zenjs": "0.0.24",
     "autoprefixer": "7.1.2",
     "axios": "^0.18.0",
     "babel-core": "6.25.0",

--- a/src/stores/executeContractStore.js
+++ b/src/stores/executeContractStore.js
@@ -1,8 +1,10 @@
 import { observable, action, runInAction, computed } from 'mobx'
-import { fromYaml, serialize } from '@zen/zenjs/build/src/Data'
+import Data, { fromYaml} from '@zen/zenjs/build/src/Data'
 
 import wallet from '../services/wallet'
 import { zenToKalapas, isZenAsset } from '../utils/zenUtils'
+import chain, {MAINNET} from "../services/chain"
+
 
 class ExecuteContractStore {
     @observable address = ''
@@ -76,12 +78,16 @@ class ExecuteContractStore {
             return ''
         }
         try {
-            fromYaml('main', this.messageBody)
+            fromYaml(this.currentChain, this.messageBody)
             return ''
         } catch (err) {
             console.error('error parsing message body', err)
             return 'Body must be valid yaml syntax'
         }
+    }
+
+    get currentChain() {
+        return chain.current === MAINNET ? 'main' : 'test'
     }
 
     @action
@@ -117,7 +123,9 @@ class ExecuteContractStore {
             data.command = this.command
         }
         if (this.messageBody) {
-            data.messageBody = serialize(fromYaml('main', this.messageBody))
+            data.messageBody = fromYaml(this.currentChain, this.messageBody)
+        } else {
+            data.messageBody = new Data.Dictionary([])
         }
         return data
     }

--- a/src/stores/publicAddressStore.js
+++ b/src/stores/publicAddressStore.js
@@ -14,7 +14,7 @@ class PublicAddressStore {
         await wallet.fetch()
         runInAction(() => {
           this.address = wallet.instance.getAddress()
-          this.pkHash = wallet.instance.getPublicKeyHash()
+          this.pkHash = wallet.instance.getPublicKeyHash().hash
           this.addressError = ''
         })
       } catch (err) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,9 +45,9 @@
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@zeit/schemas/-/schemas-2.6.0.tgz#004e8e553b4cd53d538bd38eac7bcbf58a867fe3"
 
-"@zen/zenjs@0.0.22":
-  version "0.0.22"
-  resolved "https://www.myget.org/F/zenprotocol/npm/@zen/zenjs/-/@zen/zenjs-0.0.22.tgz#d1f12918398c51f505440e3f42d2e24955237d7d"
+"@zen/zenjs@0.0.24":
+  version "0.0.24"
+  resolved "https://www.myget.org/F/zenprotocol/npm/@zen/zenjs/-/@zen/zenjs-0.0.24.tgz#695b6d1ffa7f6f22f0934f5d72ca8aba36c7c617"
   dependencies:
     aes-js "^3.1.1"
     axios "^0.18.0"


### PR DESCRIPTION
fix executeContract with respect of the new api + bump version of zenjs